### PR TITLE
set CFLAGS_ALWAYS=-fcommon to build with gcc 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OUTPUT_ACTION_CC=./bin/action_timing
 CFLAGS_ACTION_CC=-O3 -funroll-loops -fomit-frame-pointer -m64 -mbmi2 -DFP_$(BITLENGTH_OF_P) -D$(TYPE) -lm
 
 # GLOBAL FLAGS
-CFLAGS_ALWAYS=
+CFLAGS_ALWAYS=-fcommon
 
 # COMPILER
 CC=gcc


### PR DESCRIPTION
Previous gcc versions set -fcommon implicitly and gcc 10 changed the new
default value to -fno-common. This change does not solve the underlying
issues where extern should be used. This change does allow the codebase
to build with gcc 10 and also previous versions of gcc.